### PR TITLE
Make a colon (:) the separator between the rule and the state.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "style-wrap",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "style-wrap",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "A framework-agnostic web component to simplify styling HTML elements.",
     "main": "dist/index.cjs",
     "module": "dist/index.esm.js",

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ An intuitive way to style different CSS states (such as `:hover`, `:focus`, etc.
 ```html
 <style-wrap
     color="gray"
-    color.hover="black"
+    color:hover="black"
     transition="color 250ms ease-in-out"
 >
     <a> hover me to change the color! </a>

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ Create an attribute on the `style-wrap` element using the **`_`** prefix (simila
 ```css
 button {
     background: white;
-    color: var(--active); // use the CSS variable syntax to access the variable.
+    color: var(--active); /* use the CSS variable syntax to access the variable. */
 }
 
 button:hover {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export default class StyleWrap extends HTMLElement {
         if (!this.elementStyles) this.setupElementStyles();
 
         // Check for a state, like "hover", "focus", "etc"
-        let [rule, state] = name.trim().split(".");
+        let [rule, state] = name.trim().split(":");
 
         // Trim the value:
         let finalValue = value?.trim() || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import GlobalStyleManager from "./styling/GlobalStyleManager";
 import generateId from "./utils/generateId";
 
 import "./utils/es5Adapter";
+import isValidAttribute from "./utils/isValidAttribute";
 
 interface IAttributeDescriptor {
     name: string;
@@ -12,9 +13,6 @@ interface IAttributeDescriptor {
 export interface IStyleWrapConfig {
     globals?: Record<string, string>;
 }
-
-// Don't update css for these attributes:
-const ignoredAttributes = ["id", "class", "style"];
 
 export default class StyleWrap extends HTMLElement {
     static globalStyles = new GlobalStyleManager();
@@ -73,8 +71,7 @@ export default class StyleWrap extends HTMLElement {
 
     // Validate and set a style rule on the target element:
     setStyleProperty({ name, value }: IAttributeDescriptor) {
-        if (ignoredAttributes.indexOf(name) !== -1 || !this.targetElement)
-            return;
+        if (!isValidAttribute(name) || !this.targetElement) return;
 
         if (!this.elementStyles) this.setupElementStyles();
 
@@ -131,7 +128,7 @@ export default class StyleWrap extends HTMLElement {
     // Remove the element stylesheet on unmount:
     disconnectedCallback() {
         if (!this.elementStyles) return;
-        
+
         document.head.removeChild(this.elementStyles?.styleElement);
 
         this.elementStyles = undefined;

--- a/src/styling/GlobalStyleManager.ts
+++ b/src/styling/GlobalStyleManager.ts
@@ -1,6 +1,6 @@
 export default class GlobalStyleManager {
     styleElement: HTMLStyleElement = document.createElement("style");
-    startNode: Text = document.createTextNode("style-wrap{");
+    startNode: Text = document.createTextNode(":root{");
     endNode: Text = document.createTextNode("}");
 
     globalNodeMap: Record<string, Text> = {};

--- a/src/utils/isValidAttribute.ts
+++ b/src/utils/isValidAttribute.ts
@@ -1,0 +1,38 @@
+const invalidAttributes = [
+    "accesskey",
+    "autocapitalize",
+    "autofocus",
+    "class",
+    "contenteditable",
+    "contextmenu",
+    "dir",
+    "draggable",
+    "enterkeyhint",
+    "exportparts",
+    "hidden",
+    "id",
+    "inputmode",
+    "lang",
+    "nonce",
+    "part",
+    "slot",
+    "spellcheck",
+    "style",
+    "tabindex",
+    "title",
+    "translate",
+];
+
+const invalidAttributePrefixes = ["data-", "item", "on"];
+
+export default function isValidAttribute(attr: string) {
+    const formattedAttr = attr.toLowerCase().trim();
+
+    if (invalidAttributes.indexOf(formattedAttr) !== -1) return false;
+
+    for (const prefix of invalidAttributePrefixes) {
+        if (formattedAttr.startsWith(prefix)) return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Basically, before this, to change an element's color on hover you'd use `color.hover`.

However, after this change, you will use the `color:hover` attribute.

Why?

- More straightforward, the colon represents states in CSS as well.
- Vue doesn't work out of the box with the dot separator xddd.